### PR TITLE
[bugfix/#81] 사진 url이 null값일시 기본 이미지 들어가도록 코드 수정

### DIFF
--- a/book/views.py
+++ b/book/views.py
@@ -103,7 +103,7 @@ class BookDetail(APIView):
                 'page_num': page.page_num,
                 'ko_content': page.ko_content,
                 'en_content': page.en_content,
-                'image_url': page.image_url.url if page.image_url else None,
+                'image_url': page.image_url.url if page.image_url else 'https://bookg-s3-bucket.s3.ap-northeast-2.amazonaws.com/UUID.png',
                 'created_at': page.created_at,
                 'update_at': page.updated_at
             }


### PR DESCRIPTION
## 🛠️ 변경사항

사진 url로 null값 받을시 기본이미지 들어가도록 코드 수정

## ☝️ 유의사항
- 기본이미지 url 입니다
 https://bookg-s3-bucket.s3.ap-northeast-2.amazonaws.com/UUID.png


## ❗체크리스트
- [ ] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [ ] 수정 가능하도록 유연하게 작성했나요?
- [ ] 필요 없는 import문 등을 삭제했나요?
- [ ] 기존의 코드에 영향이 없는 것을 확인하였나요?


![image](https://github.com/2023-Winter-Bootcamp-Team-I/backend/assets/126770521/aa350407-12a9-49df-91d5-653e94448e4a)
![image](https://github.com/2023-Winter-Bootcamp-Team-I/backend/assets/126770521/f047946b-9c23-4a91-b226-c97e93c70cc6)
